### PR TITLE
fix is_enabled condition

### DIFF
--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -58,11 +58,9 @@ class plugininfo extends plugin implements plugin_with_buttons, plugin_with_menu
         // Disabled if:
         // - Not logged in or guest.
         // - Files are not allowed.
-        // - Only URL are supported.
         $canhavefiles = !empty($options['maxfiles']);
-        $canhaveexternalfiles = !empty($options['return_types']) && ($options['return_types'] & FILE_EXTERNAL);
 
-        return isloggedin() && !isguestuser() && ($canhavefiles || $canhaveexternalfiles);
+        return isloggedin() && !isguestuser() && $canhavefiles;
     }
 
     /**

--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -62,7 +62,7 @@ class plugininfo extends plugin implements plugin_with_buttons, plugin_with_menu
         $canhavefiles = !empty($options['maxfiles']);
         $canhaveexternalfiles = !empty($options['return_types']) && ($options['return_types'] & FILE_EXTERNAL);
 
-        return isloggedin() && !isguestuser() && $canhavefiles && $canhaveexternalfiles;
+        return isloggedin() && !isguestuser() && ($canhavefiles || $canhaveexternalfiles);
     }
 
     /**

--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -58,9 +58,7 @@ class plugininfo extends plugin implements plugin_with_buttons, plugin_with_menu
         // Disabled if:
         // - Not logged in or guest.
         // - Files are not allowed.
-        $canhavefiles = !empty($options['maxfiles']);
-
-        return isloggedin() && !isguestuser() && $canhavefiles;
+        return isloggedin() && !isguestuser() && !empty($options['maxfiles']);
     }
 
     /**


### PR DESCRIPTION
from https://github.com/moodle/moodle/blob/9587029a4609b3222a3564207aada02716d3332d/lib/editor/tiny/plugins/media/classes/plugininfo.php#L54

Making the plugin available within quiz attempt question/essay types when question Response options allow attachments.
Not a workaround for MDL-77812
