### PR TITLE
TinyMCE/Sketch: add "Image description field" directly to Sketch

### DIFF
--- a/miniPaint/sketch.css
+++ b/miniPaint/sketch.css
@@ -1,3 +1,7 @@
+.wrapper {
+    padding-bottom: 50px;
+}
+
 .fullheight {
     height: 100%;
     margin: 0;
@@ -13,17 +17,40 @@
 }
 
 .centerbutton {
+    color: #000;
     background-color: white;
     position: fixed;
-    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     text-align: center;
     width: 100%;
     bottom: 0;
 }
 
+.centerbutton #id_enteralt {
+    min-width: 70%;
+    max-height: 40px;
+    margin-left: 10px;
+    background-color: #fff;
+    color: #000;
+}
+.enteralt-container {
+    margin: 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: left;
+    width: 80%;
+}
+
 .sketchsubmit {
     padding: 5px;
     margin: 5px;
+}
+
+#wordcount {
+    display: inline;
 }
 
 @media screen and (max-width: 700px) {

--- a/miniPaint/sketch.html
+++ b/miniPaint/sketch.html
@@ -85,7 +85,18 @@
         <div id="popups"></div>
 
         <div class="centerbutton">
-            <button class="sketchsubmit">Insert Sketch</button>
+            <div class="enteralt-container">
+                <label class="col-form-label d-inline" for="id_enteralt">
+                    Describe this image for someone who cannot see it
+                    <div id="wordcount" class="d-flex justify-content-end small">
+                        (<span id="currentcount">0</span><span id="maximumcount">/125</span>)
+                    </div>
+                </label>
+                <textarea name="enteralt" id="id_enteralt" class="form-control " rows="3" maxlength="125"></textarea>
+            </div>
+            <div class='btn-insert'>
+                <button class="sketchsubmit">Insert Sketch</button>
+            </div>
         </div>
     </body>
 </html>

--- a/miniPaint/sketch.js
+++ b/miniPaint/sketch.js
@@ -6,16 +6,33 @@
 $(document).ready(function() {
     setTimeout(function() {
         var selected = window.parent.tinyMCE.activeEditor.selection.getNode();
-        if (selected.tagName == "IMG") {
+        if (selected.tagName === "IMG") {
+			$('#id_enteralt').val(selected.alt);
             open_image(selected);
         } else {
             open_image(); // Open blank testimage.png if none is found.
         }
 
+		// Set the current character count based on the image existing alt text.
+		var existingAlt = selected.alt;
+		if (existingAlt) {
+			var existingWordCount = existingAlt.length;
+			$('#currentcount').text(existingWordCount);
+		}
+
+		$("#id_enteralt").on("input keyup", function() {
+			var text = $(this).val();
+			var charCount = text.length;
+
+			// Update the current character count display.
+			$("#currentcount").text(charCount);
+		});
+
         $('.sketchsubmit').click(function(e) {
             e.preventDefault();
+			var alt = $('#id_enteralt').val();
             var dataURI = $('#canvas_minipaint')[0].toDataURL();
-            window.parent.tinyMCE.activeEditor.execCommand('mceInsertContent', 0, '<img src="'+dataURI+'" />');
+			window.parent.tinyMCE.activeEditor.execCommand('mceInsertContent', 0, '<img src="'+dataURI+'" alt="'+alt+'"/>');
             $(window.parent.document).find(".modal").find('.close').click();
         });
     }, 200);


### PR DESCRIPTION
Hi @Syxton 

Currently, adding an image description to Sketch involves a multi-step process:
Insert the Sketch.
Click on the inserted Sketch.
Click the Image button.
Fill in the description using the Insert Image interface.

**Objective**
This pull request enhancement allows users to add an image description directly when inserting a Sketch in a single, intuitive step.
Also, the field data is still editable in **_Insert Image_** as well.
Below is a screen shot of the functionality:
![image](https://github.com/Syxton/moodle-tiny_sketch/assets/55305972/8ad45e70-98bd-478f-a09e-65d6b098faf6)
