### PR TITLE
Removed not existing admin settings to prevent error - not a setting instance

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -32,6 +32,5 @@ if ($hassiteconfig) {
             get_string('forceaccessibility', 'tiny_sketch'),
             get_string('forceaccessibility_desc', 'tiny_sketch'),
             0));
-        $settings->add($setting);
     }
 }


### PR DESCRIPTION
Removed not existing admin settings to prevent error - not a setting instance

![Removed not existing admin settings to prevent error - not a setting instance](https://github.com/user-attachments/assets/86ae984f-68e2-4b5a-b23c-5a67e7340de4)
