### PR TITLE
TinyMCE/Sketch: Popup does not close

### DIFF
--- a/miniPaint/sketch.js
+++ b/miniPaint/sketch.js
@@ -43,7 +43,7 @@ $(document).ready(function() {
 					}
 				}
 				// Close window.
-				$(".modal .close", top.document).click();
+				$(window.parent.document).find('.modal .close, .modal .btn-close').click();
 			}, 200);
         });
     }, 200);


### PR DESCRIPTION
I am from The Open University.

I encountered an issue while working with the sketch plugin. The problem occurs after clicking the "Insert Sketch" button. The sketch popup does not close automatically. However, when the user clicks the "X" button, the sketch is successfully inserted.

After investigating, I found that this issue only happens in our plugin when the TinyMCE editor is loaded inside an iframe. As a result, the code to locate and close the popup's "X" button seems to malfunction.

I have provided a patch for this issue. Could you please review it?